### PR TITLE
inclusao wdev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,10 @@
         "dev": [
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+        ],
+        "wdev": [
+            "Composer\\Config::disableProcessTimeout",
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\"  \"npm run dev\" --names=server,queue,vite"
         ]
     },
     "extra": {


### PR DESCRIPTION
coloquei uma secçao de script para desesnvolvimento em windows, por que a extensão pcntl nao está disponível